### PR TITLE
Clearly demarcate the origin of Spark SQL functions

### DIFF
--- a/notebooks/3-Spark/spark-sql.ipynb
+++ b/notebooks/3-Spark/spark-sql.ipynb
@@ -277,7 +277,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "col(\"name\")\n",
+    "import org.apache.spark.sql.{functions => F}\n",
+    "\n",
+    "F.col(\"name\")\n",
     "$\"name\"\n",
     "'name"
    ]
@@ -318,10 +320,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import org.apache.spark.sql.functions._\n",
-    "\n",
     "val departmentValue = inventory.groupByKey(_.department).agg(\n",
-    "    sum('quantity * 'price).as(\"value\").as[Double]\n",
+    "    F.sum('quantity * 'price).as(\"value\").as[Double]\n",
     ").withColumnRenamed(\"key\", \"department\")\n",
     "departmentValue.show"
    ]
@@ -361,10 +361,10 @@
    "source": [
     "import org.apache.spark.sql.expressions.Window\n",
     "\n",
-    "val windowSpec = Window.partitionBy(\"id\").orderBy(desc(\"version\"))\n",
+    "val windowSpec = Window.partitionBy(\"id\").orderBy(F.desc(\"version\"))\n",
     "\n",
     "val iom = spark.read.orc(\"data/isle-of-man.orc\")\n",
-    "  .withColumn(\"row_number\", row_number().over(windowSpec))\n",
+    "  .withColumn(\"row_number\", F.row_number().over(windowSpec))\n",
     "  .filter('row_number === 1 && 'visible ===true)\n",
     "  .drop('row_number)"
    ]
@@ -408,7 +408,7 @@
    "source": [
     "val wayNds = iom\n",
     "  .filter('type === \"way\" && 'tags(\"waterway\") === \"river\")\n",
-    "  .select('id, posexplode('nds))\n",
+    "  .select('id, F.posexplode('nds))\n",
     "  .select('id, 'pos, $\"col.ref\" as \"nid\")\n",
     "wayNds.printSchema"
    ]
@@ -498,7 +498,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "val wayLength = udf(wayLengthFn(_, _, _))"
+    "val wayLength = F.udf(wayLengthFn(_, _, _))"
    ]
   },
   {
@@ -519,9 +519,9 @@
     "val wayLengths = wayXYs \n",
     "  .groupBy('id)\n",
     "  .agg(\n",
-    "    collect_list('pos) as \"pos\", \n",
-    "    collect_list('lat) as \"lat\", \n",
-    "    collect_list('lon) as \"lon\"\n",
+    "    F.collect_list('pos) as \"pos\", \n",
+    "    F.collect_list('lat) as \"lat\", \n",
+    "    F.collect_list('lon) as \"lon\"\n",
     "  )\n",
     "  .select('id, wayLength('pos, 'lon, 'lat) as 'length)\n",
     "\n",
@@ -544,7 +544,7 @@
    "outputs": [],
    "source": [
     "wayLengths\n",
-    "  .agg(sum('length))\n",
+    "  .agg(F.sum('length))\n",
     "  .first\n",
     "  .getDouble(0)"
    ]
@@ -567,7 +567,7 @@
    "outputs": [],
    "source": [
     "try {\n",
-    "    udf(reconstructLineString(_, _, _))\n",
+    "    F.udf(reconstructLineString(_, _, _))\n",
     "    ()\n",
     "} catch {\n",
     "    case e: Exception => println(e)\n",
@@ -628,7 +628,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "val convertToLineString = udf(reconstructLineString(_, _, _))"
+    "val convertToLineString = F.udf(reconstructLineString(_, _, _))"
    ]
   },
   {
@@ -649,9 +649,9 @@
     "val wayGeoms = wayXYs \n",
     "  .groupBy('id)\n",
     "  .agg(\n",
-    "    collect_list('pos) as \"pos\", \n",
-    "    collect_list('lat) as \"lat\", \n",
-    "    collect_list('lon) as \"lon\"\n",
+    "    F.collect_list('pos) as \"pos\", \n",
+    "    F.collect_list('lat) as \"lat\", \n",
+    "    F.collect_list('lon) as \"lon\"\n",
     "  )\n",
     "  .select('id, convertToLineString('pos, 'lon, 'lat) as 'geom)\n",
     "wayGeoms.printSchema"
@@ -677,7 +677,7 @@
     "\n",
     "wayGeoms\n",
     "  .select(st_lengthSphere('geom) as 'length)\n",
-    "  .agg(sum('length))\n",
+    "  .agg(F.sum('length))\n",
     "  .first\n",
     "  .getDouble(0)"
    ]


### PR DESCRIPTION
A slightly out-of-order import caused a bug.  Rather than just fix it, I swapped over to being more explicit about identifying when a function was provided by `org.apache.spark.sql.functions`.

Closes #6 